### PR TITLE
fix: add settings write with new values for lids and bottoms

### DIFF
--- a/src/controller.py
+++ b/src/controller.py
@@ -325,6 +325,8 @@ class MainController:
         s.slicing.fan_speed = float(self.view.fan_speed_value.text())
         s.slicing.supports_on = self.view.supports_on_box.isChecked()
         s.slicing.angle = float(self.view.colorize_angle_value.text())
+        s.slicing.lids_depth = int(self.view.number_of_lid_layers_value.text())
+        s.slicing.bottom_layers = int(self.view.number_of_bottom_layers_value.text())
 
         s.slicing.overlapping_infill_percentage = float(self.view.overlapping_infill_value.text())
 

--- a/src/locales.py
+++ b/src/locales.py
@@ -14,7 +14,7 @@ class Locale:
     BottomThickness='Bottom thickness:'
     NumberOfBottomLayers='Number of bottom layers:'
     LidsThickness='Lid thickness:'
-    NumberOfLidsLayers='Number of lid layers:'
+    NumberOfLidLayers='Number of lid layers:'
     LineWidth = 'Extruder diameter, mm:'
     FillingType = 'Filling type:'
     FillingTypeValues = ["Lines", "Squares", "Triangles"]


### PR DESCRIPTION
Settings for lids were not updated when user wanted to slice something.

P.S. We do not have yet `bottom_layers` feature in goosli, I think it is for future... But better to update it now