### PR TITLE
fix: printer import

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ vtk>=9.0.0
 numpy==1.22.0
 qdarkstyle==3.1
 numpy-stl
+requests

--- a/src/calibration/controller.py
+++ b/src/calibration/controller.py
@@ -62,7 +62,7 @@ class CalibrationController(QObject):
         self.view.progressBar.setVisible(False)
         self.view.label.setText(self.steps[self.step].labelText)
 
-    def __init__(self, view, steps):
+    def __init__(self, view, model):
         super().__init__()
 
         self.messageBox = QMessageBox()
@@ -70,7 +70,7 @@ class CalibrationController(QObject):
         self.textResults = []
 
         self.view = view
-        self.steps = steps
+        self.steps = model.steps
 
         view.btnNext.clicked.connect(self.clickNext)
         view.btnCancel.clicked.connect(self.view.close)

--- a/src/calibration/model.py
+++ b/src/calibration/model.py
@@ -1,6 +1,6 @@
 from .steps import StepsCollection
 
 
-class CalibrationModel(StepsCollection):
-    def __init__(self):
-        super().__init__()
+class CalibrationModel():
+    def __init__(self, printer):
+        self.steps = StepsCollection(printer)

--- a/src/calibration/steps.py
+++ b/src/calibration/steps.py
@@ -1,5 +1,4 @@
 import math
-import printer
 from .data import CalibrationData
 from .reprapfirmware_lsq import Tuner
 
@@ -10,12 +9,12 @@ class Container:
     rawScale = b''
     rawSkew = b''
     rawAdjustV = b''
-    fixture2Height = 0.15
+    fixture2Height = 0.1
 
 
 class StepsCollection:
-    def __init__(self):
-        self.printer = printer.EpitPrinter()
+    def __init__(self, printer):
+        self.printer = printer
         self.printer.setOutputMethod(print)
         self.printer.setStatusMethod(print)
 

--- a/src/controller.py
+++ b/src/controller.py
@@ -7,6 +7,7 @@ import time
 import sys
 import src.service as service
 import src.calibration as calibration
+import src.printer as printer
 from functools import partial
 from pathlib import Path
 import shutil
@@ -29,12 +30,13 @@ class MainController:
         self.view = view
         self.model = model
 
+        self.printer = printer.EpitPrinter()
         # embed service tool
         self.servicePanel = service.ServicePanel(view)
         self.servicePanel.setModal(True)
         self.serviceController = service.ServiceController(
             self.servicePanel,
-            service.ServiceModel()
+            service.ServiceModel(self.printer)
         )
 
         # embed calibration tool
@@ -42,7 +44,7 @@ class MainController:
         self.calibrationPanel.setModal(True)
         self.calibrationController = calibration.CalibrationController(
             self.calibrationPanel,
-            calibration.CalibrationModel()
+            calibration.CalibrationModel(self.printer)
         )
 
         self._connect_signals()

--- a/src/service/controller.py
+++ b/src/service/controller.py
@@ -73,13 +73,14 @@ class ServiceController(QObject):
 
     workSignal = pyqtSignal([object], [object, list])
 
-    def __init__(self, view, printer):
+    def __init__(self, view, model):
         super().__init__()
 
         view.showedSignal.connect(self.showSlot)
         view.closedSignal.connect(self.closeSlot)
 
         worker = Worker()
+        printer = model.printer
 
         printer.setOutputMethod(lambda text: worker.outputSignal.emit(text))
         printer.setStatusMethod(lambda text: worker.statusSignal.emit(text))

--- a/src/service/model.py
+++ b/src/service/model.py
@@ -1,6 +1,3 @@
-from printer import EpitPrinter
-
-
-class ServiceModel(EpitPrinter):
-    def __init__(self):
-        super().__init__()
+class ServiceModel():
+    def __init__(self, printer):
+        self.printer = printer


### PR DESCRIPTION
There is a problem with importing printer package after calibration was embedded to spycer. And it is necessary to add src folder to PYTHONPATH. This pr makes printer import in the main controller module. 