### PR TITLE
fix: update project path on load

### DIFF
--- a/main.py
+++ b/main.py
@@ -33,6 +33,9 @@ if __name__ == "__main__":
     def open_project(project_path: str):
         load_settings(str(pathlib.Path(project_path, "settings.yaml")))
 
+        # update project_path in settings, because it originally might be in another place
+        sett().project_path = project_path
+
         window = MainWindow()
         window.close_signal.connect(entry_window.show)
         


### PR DESCRIPTION
Found a problem that `project_path` in settings didn't update when we open project.