### PR TITLE
fix: get path from builder, ensure int

### DIFF
--- a/src/figure_editor.py
+++ b/src/figure_editor.py
@@ -95,7 +95,8 @@ class FigureEditor(QWidget):
             slider.setOrientation(QtCore.Qt.Horizontal)
             slider.setMinimum(constrains[param_idx][0])
             slider.setMaximum(constrains[param_idx][1])
-            slider.setValue((initial_params.get(param, 0)))
+            # slider is int, ensure that it will not get float
+            slider.setValue(int(initial_params.get(param, 0)))
             slider.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
             slider.setMinimumWidth(200)
 

--- a/src/window.py
+++ b/src/window.py
@@ -13,7 +13,7 @@ from vtk.qt.QVTKRenderWindowInteractor import QVTKRenderWindowInteractor
 from src import locales, gui_utils, interactor_style
 from src.InteractorAroundActivePlane import InteractionAroundActivePlane
 from src.gui_utils import plane_tf, Plane, Cone
-from src.settings import sett, get_color, save_settings
+from src.settings import sett, get_color, save_settings, PathBuilder
 from src.figure_editor import StlMovePanel
 
 NothingState = "nothing"
@@ -1180,8 +1180,7 @@ class MainWindow(QMainWindow):
 
     def hide_colorize(self):
         if isinstance(self.stlActor, src.gui_utils.ColorizedStlActor):
-            s = sett()
-            stl_actor = gui_utils.createStlActorInOrigin(s.slicing.stl_file)
+            stl_actor = gui_utils.createStlActorInOrigin(PathBuilder().stl_model())
             stl_actor.lastMove = self.stlActor.lastMove
             boxWidget = self.boxWidget
             axesWidget = self.axesWidget


### PR DESCRIPTION
- missed one place where we do not use path builder to get path to stl
- figure editor fails sometimes when slider receives float instead of int, added conversion