### PR TITLE
feat: add setting with printer config path

### DIFF
--- a/settings.yaml
+++ b/settings.yaml
@@ -19,6 +19,7 @@ common:
   opacity_table: 0.3
   splane_diameter: 150
 hardware:
+  printer_dir: ""
   bar_diameter: 1.75
   calibration_file: data/calibration_data.csv
   calibration_file_zero: data/calibration_data_zero.csv

--- a/src/controller.py
+++ b/src/controller.py
@@ -154,7 +154,10 @@ class MainController:
             self.view.printer_path_edit.setText(os.path.basename(printer_path))
 
             # update path in calibration model
-            self.calibrationController.updateCalibrationFilepath(PathBuilder.calibration_file())
+            try:
+                self.calibrationController.updateCalibrationFilepath(PathBuilder.calibration_file())
+            except AttributeError:
+                print("hardware module is unavailable, skip")
 
     def moving_figure(self, sourceParent, previousRow):
         if sourceParent.row() != -1:

--- a/src/controller.py
+++ b/src/controller.py
@@ -14,6 +14,7 @@ from vtkmodules.vtkCommonMath import vtkMatrix4x4
 
 import vtk
 from PyQt5 import QtCore
+from PyQt5.QtWidgets import QFileDialog
 
 from src import gui_utils, locales, qt_utils
 from src.figure_editor import PlaneEditor, ConeEditor
@@ -55,7 +56,7 @@ class MainController:
             self.calibrationPanel.setModal(True)
             self.calibrationController = calibration.CalibrationController(
                 self.calibrationPanel,
-                calibration.CalibrationModel(self.printer)
+                calibration.CalibrationModel(self.printer, sett().hardware.calibration_file)
             )
         except:
             print("printer is not initialized")
@@ -93,6 +94,7 @@ class MainController:
             )
 
         # right panel
+        self.view.printer_path_edit.clicked.connect(self.choose_printer_path)
         self.view.number_wall_lines_value.textChanged.connect(self.update_wall_thickness)
         self.view.line_width_value.textChanged.connect(self.update_wall_thickness)
         self.view.layer_height_value.textChanged.connect(self.change_layer_height)
@@ -132,6 +134,27 @@ class MainController:
         save_splanes_to_file(self.model.splanes, splanes_full_pth)
         sett().slicing.splanes_file = path.basename(splanes_full_pth)
         save_settings()
+
+    def choose_printer_path(self):
+        printer_path = QFileDialog.getExistingDirectory(
+            self.view,
+            "Choose printer path", # TODO: add locale
+            sett().hardware.printer_dir
+        )
+
+        if printer_path:
+            sett().hardware.printer_dir = printer_path
+            # calibration file will be at default location
+            sett().hardware.calibration_file = "calibration_data.csv"
+            
+            # save settings
+            save_settings()
+
+            # update label with printer path
+            self.view.printer_path_edit.setText(os.path.basename(printer_path))
+
+            # update path in calibration model
+            self.calibrationController.updateCalibrationFilepath(PathBuilder.calibration_file())
 
     def moving_figure(self, sourceParent, previousRow):
         if sourceParent.row() != -1:

--- a/src/controller.py
+++ b/src/controller.py
@@ -56,7 +56,7 @@ class MainController:
             self.calibrationPanel.setModal(True)
             self.calibrationController = calibration.CalibrationController(
                 self.calibrationPanel,
-                calibration.CalibrationModel(self.printer, sett().hardware.calibration_file)
+                calibration.CalibrationModel(self.printer, PathBuilder.calibration_file())
             )
         except:
             print("printer is not initialized")
@@ -138,7 +138,7 @@ class MainController:
     def choose_printer_path(self):
         printer_path = QFileDialog.getExistingDirectory(
             self.view,
-            "Choose printer path", # TODO: add locale
+            locales.getLocale().ChoosePrinterDirectory,
             sett().hardware.printer_dir
         )
 

--- a/src/locales.py
+++ b/src/locales.py
@@ -116,6 +116,9 @@ class Locale:
     ErrorHardwareModule = "Hardware module is unavailable in public"
     ErrorBugModule = "Bug reporting is unavailable in public"
 
+    PrinterName = "Printer name:"
+    ChoosePrinterDirectory = "Choose printer directory"
+
     def __init__(self, **entries):
         self.__dict__.update(entries)
 
@@ -236,7 +239,10 @@ dicts = {
         ErrorReport = "Произошла ошибка при отправке отчета",
 
         ErrorHardwareModule = "Модуль калибровки недоступен публично",
-        ErrorBugModule = "Модуль отправки багов недоступен публично"
+        ErrorBugModule = "Модуль отправки багов недоступен публично",
+
+        PrinterName = "Название принтера:",
+        ChoosePrinterDirectory = "Выберите директорию принтера",
     ),
 }
 

--- a/src/qt_utils.py
+++ b/src/qt_utils.py
@@ -1,8 +1,17 @@
 import concurrent.futures
 from PyQt5 import QtCore
 from PyQt5.QtCore import QEventLoop
-from PyQt5.QtWidgets import QProgressDialog
+from PyQt5.QtWidgets import QProgressDialog, QLineEdit
+from PyQt5.QtCore import Qt
 
+class ClickableLineEdit(QLineEdit):
+    clicked = QtCore.pyqtSignal()
+
+    def mousePressEvent(self, event):
+        if event.button() == Qt.LeftButton: 
+            self.clicked.emit()
+        else: 
+            super().mousePressEvent(event)
 
 class TaskManager(QtCore.QObject):
     # source: https://stackoverflow.com/questions/64500883/pyqt5-widget-qthread-issue-when-using-concurrent-futures-threadpoolexecutor

--- a/src/settings.py
+++ b/src/settings.py
@@ -134,3 +134,10 @@ class PathBuilder:
     def gcode_file():
         return path.join(PathBuilder.project_path(), sett().slicing.gcode_file)
     
+    @staticmethod
+    def printer_dir():
+        return sett().hardware.printer_dir
+
+    @staticmethod
+    def calibration_file():
+        return path.join(PathBuilder.printer_dir(), sett().hardware.calibration_file)

--- a/src/window.py
+++ b/src/window.py
@@ -15,6 +15,8 @@ from src.InteractorAroundActivePlane import InteractionAroundActivePlane
 from src.gui_utils import plane_tf, Plane, Cone
 from src.settings import sett, get_color, save_settings, PathBuilder
 from src.figure_editor import StlMovePanel
+from src.qt_utils import ClickableLineEdit
+import os.path as path
 
 NothingState = "nothing"
 GCodeState = "gcode"
@@ -291,6 +293,20 @@ class MainWindow(QMainWindow):
 
         def get_cur_row():
             return self.cur_row
+        
+        # printer choice
+        printer_label = QLabel("Printer config")
+
+        printer_basename = ""
+        try:
+            printer_basename = path.basename(sett().hardware.printer_dir)
+        except:
+            # set default path to printer config
+            sett().hardware.printer_dir = ""
+        self.printer_path_edit = ClickableLineEdit(printer_basename)
+        self.printer_path_edit.setReadOnly(True)
+        right_panel.addWidget(printer_label, get_next_row(), 1)
+        right_panel.addWidget(self.printer_path_edit, get_cur_row(), 2, 1, сolumn2_number_of_cells)
 
         line_width_label = QLabel(self.locale.LineWidth)
         self.line_width_value = LineEdit(str(sett().slicing.line_width))

--- a/src/window.py
+++ b/src/window.py
@@ -295,7 +295,7 @@ class MainWindow(QMainWindow):
             return self.cur_row
         
         # printer choice
-        printer_label = QLabel("Printer config")
+        printer_label = QLabel(locales.getLocale().PrinterName)
 
         printer_basename = ""
         try:


### PR DESCRIPTION
added setting where we will chose path that points to directory with printer config

for now we will place only calibration_data.csv after calibration, but it can be extended later

![image](https://github.com/epit3d/spycer/assets/42120385/7659faff-261b-4d04-a97b-a2118a0cdae3)

Related:
- https://github.com/epit3d/goosli_v2/pull/102
- https://github.com/epit3d/hardware/pull/1