### PR TITLE
fix: update which setting is saved

### DIFF
--- a/src/controller.py
+++ b/src/controller.py
@@ -888,14 +888,8 @@ class MainController:
         self.view.supports_number_of_bottom_layers_value.setText(
             str(s.supports.bottoms_depth)
         )
-        self.view.supports_bottom_thickness_value.setText(
-            str(round(s.slicing.layer_height * s.supports.bottoms_depth, 2))
-        )
         self.view.supports_number_of_lid_layers_value.setText(
             str(int(s.supports.lids_depth))
-        )
-        self.view.supports_lid_thickness_value.setText(
-            str(round(s.slicing.layer_height * s.supports.lids_depth, 2))
         )
         self.view.colorize_angle_value.setText(str(s.slicing.angle))
 

--- a/src/settings_widget.py
+++ b/src/settings_widget.py
@@ -568,7 +568,7 @@ class SettingsWidget(QWidget):
 
             def on_change():
                 self.sett().slicing.bottoms_depth = self.__smart_float(
-                    bottom_thickness_value.text()
+                    number_of_bottom_layers_value.text()
                 )
 
             number_of_bottom_layers_value.textChanged.connect(on_change)
@@ -610,7 +610,7 @@ class SettingsWidget(QWidget):
 
             def on_change():
                 self.sett().slicing.lids_depth = self.__smart_float(
-                    lid_thickness_value.text()
+                    number_of_lids_layers_value.text()
                 )
 
             number_of_lids_layers_value.textChanged.connect(on_change)
@@ -1186,7 +1186,7 @@ class SettingsWidget(QWidget):
 
             def on_change():
                 self.sett().supports.bottoms_depth = self.__smart_float(
-                    bottom_thickness_value.text()
+                    support_number_of_bottom_layers_value.text()
                 )
 
             support_number_of_bottom_layers_value.textChanged.connect(on_change)
@@ -1231,7 +1231,7 @@ class SettingsWidget(QWidget):
 
             def on_change():
                 self.sett().supports.lids_depth = self.__smart_float(
-                    lid_thickness_value.text()
+                    support_number_of_lid_layers_value.text()
                 )
 
             support_number_of_lid_layers_value.textChanged.connect(on_change)


### PR DESCRIPTION
We have had a problem about disappearing bottoms and lids. It was due wrong name of the setting we saved from. For instance, instead of integer with the number of layers we expect, we have saved a thickness value.