### PR TITLE
fix: add icons to build

### DIFF
--- a/.github/workflows/build-linux.yaml
+++ b/.github/workflows/build-linux.yaml
@@ -47,6 +47,7 @@ jobs:
         run: |
           mv settings.yaml dist/settings.yaml
           mv icon.png dist/icon.png
+          mv icons/ dist/icons/
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -43,6 +43,7 @@ jobs:
         run: |
           mv settings.yaml dist/settings.yaml
           mv icon.png dist/icon.png
+          mv icons/ dist/icons/
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:

--- a/main.py
+++ b/main.py
@@ -76,6 +76,11 @@ if __name__ == "__main__":
             del sett().slicing.splanes_file
 
             cntrl.save_settings("vip")
+        else:
+            # load splanes from settings
+            cntrl.load_planes(
+                [read_plane(figure.description) for figure in sett().figures]
+            )
 
     def open_project(project_path: str):
         load_settings(str(pathlib.Path(project_path, "settings.yaml")))


### PR DESCRIPTION
In this PR I copy icons to dist/ directory during build phase. Also I fix silly bug made in previous PR by poor copy.

In the latest dev version splanes are not created even if present