### PR TITLE
Fix validator locale in settings widget

### DIFF
--- a/src/settings_widget.py
+++ b/src/settings_widget.py
@@ -53,7 +53,7 @@ class SettingsWidget(QToolBox):
     """
 
     col2_cells = 4
-    validatorLocale = QtCore.QLocale("Englishs")
+    validatorLocale = QtCore.QLocale("en_US")
     intValidator = QtGui.QIntValidator(0, 9000)
 
     doubleValidator = QtGui.QDoubleValidator(0.00, 9000.00, 2)


### PR DESCRIPTION
## Summary
- use a valid `en_US` locale for numeric validators in `SettingsWidget`

## Testing
- `PYTHONPATH=. pytest` *(fails: ModuleNotFoundError: No module named 'PyQt5')*


------
https://chatgpt.com/codex/tasks/task_b_68a8673e151c83318698fce94b75cf2c