### PR TITLE
Refactor settings paths to use pathlib

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,27 +1,26 @@
 # if we run pyinstaller build for linux, we have to extend LD_LIBRARY_PATH with goosli dependencies
-import os, sys
+import logging
+import os
+import sys
+from pathlib import Path
 
 # check whether we are in pyinstaller bundle and on linux
 if getattr(sys, "frozen", False) and sys.platform.startswith("linux"):
-    app_path = os.path.dirname(sys.executable)
+    app_path = Path(sys.executable).parent
 
     prev_ld_path = os.environ.get("LD_LIBRARY_PATH", "")
 
     # shared libraries are located at lib/
-    shared_libs = os.path.join(app_path, "lib")
+    shared_libs = app_path / "lib"
 
     # add shared libraries to LD_LIBRARY_PATH
-    os.environ["LD_LIBRARY_PATH"] = shared_libs + ":" + prev_ld_path
+    os.environ["LD_LIBRARY_PATH"] = str(shared_libs) + ":" + prev_ld_path
     logging.debug("LD_LIBRARY_PATH: %s", os.environ["LD_LIBRARY_PATH"])
 
 
-import logging
-import sys
 import traceback
-import os
 from PyQt5 import QtWidgets
 from PyQt5.QtWidgets import QApplication
-import pathlib
 from src.settings import (
     copy_project_files,
     load_settings,
@@ -68,8 +67,8 @@ if __name__ == "__main__":
             # TODO: we can remove this condition after one release
 
             # try to open figures file
-            figpath = pathlib.Path(project_path, sett().slicing.splanes_file)
-            if os.path.isfile(figpath):
+            figpath = Path(project_path) / sett().slicing.splanes_file
+            if figpath.is_file():
                 cntrl.load_planes_from_file(figpath)
             else:
                 cntrl.load_planes([])
@@ -84,7 +83,7 @@ if __name__ == "__main__":
             )
 
     def open_project(project_path: str):
-        load_settings(str(pathlib.Path(project_path, "settings.yaml")))
+        load_settings(Path(project_path) / "settings.yaml")
 
         # update project_path in settings, because it originally might be in another place
         sett().project_path = project_path
@@ -99,8 +98,8 @@ if __name__ == "__main__":
         cntrl = MainController(window, model)
 
         # try to open stl file
-        stlpath = pathlib.Path(project_path, sett().slicing.stl_file)
-        if os.path.isfile(stlpath):
+        stlpath = Path(project_path) / sett().slicing.stl_file
+        if stlpath.is_file():
             cntrl.load_stl(stlpath)
 
         splanes_update(project_path, cntrl)
@@ -113,7 +112,7 @@ if __name__ == "__main__":
 
     def create_project(project_path: str):
         copy_project_files(project_path)
-        load_settings(str(pathlib.Path(project_path, "settings.yaml")))
+        load_settings(Path(project_path) / "settings.yaml")
         create_temporary_project_files()
 
         window = MainWindow()
@@ -140,7 +139,8 @@ if __name__ == "__main__":
     logging.info("event loop exited")
 
     s = sett()
-    if os.path.isfile(s.colorizer.copy_stl_file):
-        os.remove(s.colorizer.copy_stl_file)
+    copy_path = Path(s.colorizer.copy_stl_file)
+    if copy_path.is_file():
+        copy_path.unlink()
 
     sys.exit(ret)

--- a/src/client.py
+++ b/src/client.py
@@ -2,8 +2,8 @@ import src.server_api.pyapi.srv_bug.srv_bug_pb2 as srv_bug_pb2
 import logging
 import src.server_api.pyapi.srv_bug.srv_bug_pb2_grpc as srv_bug_pb2_grpc
 import grpc
-import os
 import yaml
+from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
@@ -42,7 +42,7 @@ def send_bug_report(filename, error_description):
         stub = srv_bug_pb2_grpc.BugServiceStub(channel)
 
         # check if file exists
-        if not os.path.exists(filename):
+        if not Path(filename).exists():
             logger.error("File not found: %s", filename)
             return False
 

--- a/test/compare_files_test.py
+++ b/test/compare_files_test.py
@@ -1,9 +1,10 @@
-import os
 import sys
 import types
 import tempfile
 import unittest
 from unittest import mock
+
+from pathlib import Path
 
 import qt_stubs  # noqa: F401
 
@@ -19,42 +20,42 @@ class DummyNamedColors:
 vtk_stub.vtkNamedColors = DummyNamedColors
 sys.modules["vtk"] = vtk_stub
 
-from src.settings import compare_files
+from src.settings import compare_files  # noqa: E402
 
 
 class CompareFilesTest(unittest.TestCase):
     def test_missing_first_file_returns_false(self):
         with tempfile.NamedTemporaryFile(delete=False) as temp_file:
             temp_file.write(b"data")
-            existing_path = temp_file.name
-        missing_path = existing_path + "_missing"
+            existing_path = Path(temp_file.name)
+        missing_path = existing_path.with_name(existing_path.name + "_missing")
         self.assertFalse(compare_files(missing_path, existing_path))
-        os.remove(existing_path)
+        existing_path.unlink()
 
     def test_missing_second_file_returns_false(self):
         with tempfile.NamedTemporaryFile(delete=False) as temp_file:
             temp_file.write(b"data")
-            existing_path = temp_file.name
-        missing_path = existing_path + "_missing"
+            existing_path = Path(temp_file.name)
+        missing_path = existing_path.with_name(existing_path.name + "_missing")
         self.assertFalse(compare_files(existing_path, missing_path))
-        os.remove(existing_path)
+        existing_path.unlink()
 
     def test_both_files_missing_returns_false(self):
         import uuid
 
-        missing1 = os.path.join(tempfile.gettempdir(), uuid.uuid4().hex)
-        missing2 = os.path.join(tempfile.gettempdir(), uuid.uuid4().hex)
+        missing1 = Path(tempfile.gettempdir()) / uuid.uuid4().hex
+        missing2 = Path(tempfile.gettempdir()) / uuid.uuid4().hex
         self.assertFalse(compare_files(missing1, missing2))
 
     def test_file_not_found_during_read_returns_false(self):
         with tempfile.NamedTemporaryFile(delete=False) as f1:
-            path1 = f1.name
+            path1 = Path(f1.name)
         with tempfile.NamedTemporaryFile(delete=False) as f2:
-            path2 = f2.name
-        with mock.patch("builtins.open", side_effect=FileNotFoundError()):
+            path2 = Path(f2.name)
+        with mock.patch("pathlib.Path.open", side_effect=FileNotFoundError()):
             self.assertFalse(compare_files(path1, path2))
-        os.remove(path1)
-        os.remove(path2)
+        path1.unlink()
+        path2.unlink()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- use `pathlib.Path` for path handling in settings
- switch client, main, and tests to `Path`

## Testing
- `ruff format src/settings.py src/client.py test/compare_files_test.py main.py`
- `ruff check src/settings.py src/client.py test/compare_files_test.py main.py`
- `PYTHONPATH=. pytest test/compare_files_test.py`


------
https://chatgpt.com/codex/tasks/task_b_68c81ffd3e248331ad883b73a755e6bf