### PR TITLE
Refactor window and controller into modular packages

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,10 @@
+"""Core package exposing primary interfaces for Spycer."""
+
+try:  # pragma: no cover - optional Qt dependencies
+    from .window import MainWindow
+    from .controller import MainController
+except Exception:  # when Qt is missing during lightweight imports
+    MainWindow = None  # type: ignore
+    MainController = None  # type: ignore
+
+__all__ = ["MainWindow", "MainController"]

--- a/src/controller/__init__.py
+++ b/src/controller/__init__.py
@@ -1,4 +1,5 @@
 """Controller package exposing the main application controller."""
+
 from .main import MainController
 
 __all__ = ["MainController"]

--- a/src/controller/__init__.py
+++ b/src/controller/__init__.py
@@ -1,0 +1,4 @@
+"""Controller package exposing the main application controller."""
+from .main import MainController
+
+__all__ = ["MainController"]

--- a/src/controller/file_management.py
+++ b/src/controller/file_management.py
@@ -1,4 +1,5 @@
 """File-related controller mixins."""
+
 import os
 import shutil
 from os import path
@@ -8,12 +9,11 @@ import logging
 
 from PyQt5.QtWidgets import QFileDialog, QMessageBox
 
-from src import gui_utils, locales, qt_utils
+from src import gui_utils, locales
 from src.gui_utils import showErrorDialog
 from src.process import Process
 from src.settings import (
     sett,
-    save_settings,
     load_settings,
     PathBuilder,
     create_temporary_project_files,
@@ -71,7 +71,9 @@ class FileManagementMixin:
 
     def save_settings_file(self):
         try:
-            directory = "Settings_" + os.path.basename(sett().slicing.stl_file).split(".")[0]
+            directory = (
+                "Settings_" + os.path.basename(sett().slicing.stl_file).split(".")[0]
+            )
             filename = str(
                 self.view.save_dialog(
                     self.view.locale.SaveSettings, "YAML (*.yaml *.YAML)", directory
@@ -151,9 +153,7 @@ class FileManagementMixin:
                         sett().project_path = old_project_path
                         self.display_settings()
                     except Exception as e:
-                        showErrorDialog(
-                            "Error during reading settings file: " + str(e)
-                        )
+                        showErrorDialog("Error during reading settings file: " + str(e))
                 else:
                     showErrorDialog("This file format isn't supported:" + file_ext)
         except IOError as e:

--- a/src/controller/file_management.py
+++ b/src/controller/file_management.py
@@ -1,0 +1,175 @@
+"""File-related controller mixins."""
+import os
+import shutil
+from os import path
+from pathlib import Path
+from shutil import copy2
+import logging
+
+from PyQt5.QtWidgets import QFileDialog, QMessageBox
+
+from src import gui_utils, locales, qt_utils
+from src.gui_utils import showErrorDialog
+from src.process import Process
+from src.settings import (
+    sett,
+    save_settings,
+    load_settings,
+    PathBuilder,
+    create_temporary_project_files,
+    update_last_open_project,
+    get_recent_projects,
+    delete_temporary_project_files,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class FileManagementMixin:
+    """Encapsulates file handling logic for controllers."""
+
+    # Methods below are copied from the legacy ``MainController``
+    # to isolate responsibilities.
+    def open_file(self):
+        try:
+            filename = str(self.view.open_dialog(self.view.locale.OpenModel))
+            if filename != "":
+                file_ext = os.path.splitext(filename)[1].upper()
+                filename = str(Path(filename))
+                if file_ext == ".STL":
+                    self.reset_settings()
+                    s = sett()
+                    stl_full_path = PathBuilder.stl_model_temp()
+                    shutil.copyfile(filename, stl_full_path)
+                    s.slicing.stl_filename = path.basename(filename)
+                    s.slicing.stl_file = path.basename(stl_full_path)
+                    self.save_settings("vip")
+                    self.update_interface(filename)
+                    self.view.model_centering_box.setChecked(False)
+                    if os.path.isfile(s.colorizer.copy_stl_file):
+                        os.remove(s.colorizer.copy_stl_file)
+                    self.load_stl(stl_full_path)
+                elif file_ext == ".GCODE":
+                    s = sett()
+                    self.save_settings("vip")
+                    self.load_gcode(filename, False)
+                    self.update_interface(filename)
+                else:
+                    showErrorDialog("This file format isn't supported:" + file_ext)
+        except IOError as e:
+            showErrorDialog("Error during file opening:" + str(e))
+
+    def save_gcode_file(self):
+        try:
+            name = str(self.view.save_gcode_dialog())
+            if name != "":
+                if not name.endswith(".gcode"):
+                    name += ".gcode"
+                copy2(PathBuilder.gcode_file(), name)
+        except IOError as e:
+            showErrorDialog("Error during file saving:" + str(e))
+
+    def save_settings_file(self):
+        try:
+            directory = "Settings_" + os.path.basename(sett().slicing.stl_file).split(".")[0]
+            filename = str(
+                self.view.save_dialog(
+                    self.view.locale.SaveSettings, "YAML (*.yaml *.YAML)", directory
+                )
+            )
+            if filename != "":
+                if not (filename.endswith(".yaml") or filename.endswith(".YAML")):
+                    filename += ".yaml"
+                self.save_settings("vip", filename)
+        except IOError as e:
+            showErrorDialog("Error during file saving:" + str(e))
+
+    def save_project_files(self, save_path=""):
+        if save_path == "":
+            self.save_settings("vip", PathBuilder.settings_file())
+            if os.path.isfile(PathBuilder.stl_model_temp()):
+                shutil.copy2(PathBuilder.stl_model_temp(), PathBuilder.stl_model())
+        else:
+            self.save_settings("vip", path.join(save_path, "settings.yaml"))
+            if os.path.isfile(PathBuilder.stl_model_temp()):
+                shutil.copy2(
+                    PathBuilder.stl_model_temp(), path.join(save_path, "model.stl")
+                )
+
+    def save_project(self):
+        try:
+            self.save_project_files()
+            create_temporary_project_files()
+            self.successful_saving_project()
+        except IOError as e:
+            showErrorDialog("Error during project saving: " + str(e))
+
+    def save_project_as(self):
+        project_path = PathBuilder.project_path()
+        try:
+            save_directory = str(
+                QFileDialog.getExistingDirectory(
+                    self.view, locales.getLocale().SavingProject
+                )
+            )
+            if not save_directory:
+                return
+            self.save_project_files(save_directory)
+            sett().project_path = save_directory
+            self.save_settings("vip", PathBuilder.settings_file())
+            create_temporary_project_files()
+            delete_temporary_project_files(project_path)
+            recent_projects = get_recent_projects()
+            update_last_open_project(recent_projects, save_directory)
+            self.successful_saving_project()
+        except IOError as e:
+            sett().project_path = project_path
+            self.save_settings("vip")
+            showErrorDialog("Error during project saving: " + str(e))
+
+    def successful_saving_project(self):
+        message_box = QMessageBox(parent=self.view)
+        message_box.setWindowTitle(locales.getLocale().SavingProject)
+        message_box.setText(locales.getLocale().ProjectSaved)
+        message_box.setIcon(QMessageBox.Information)
+        message_box.exec_()
+
+    def load_settings_file(self):
+        try:
+            filename = str(
+                self.view.open_dialog(
+                    self.view.locale.LoadSettings, "YAML (*.yaml *.YAML)"
+                )
+            )
+            if filename != "":
+                file_ext = os.path.splitext(filename)[1].upper()
+                filename = str(Path(filename))
+                if file_ext == ".YAML":
+                    try:
+                        old_project_path = sett().project_path
+                        load_settings(filename)
+                        sett().project_path = old_project_path
+                        self.display_settings()
+                    except Exception as e:
+                        showErrorDialog(
+                            "Error during reading settings file: " + str(e)
+                        )
+                else:
+                    showErrorDialog("This file format isn't supported:" + file_ext)
+        except IOError as e:
+            showErrorDialog("Error during file opening:" + str(e))
+
+    def display_settings(self):
+        self.view.setts.reload()
+
+    def colorize_model(self):
+        shutil.copyfile(PathBuilder.stl_model_temp(), PathBuilder.colorizer_stl())
+        self.save_settings("vip", PathBuilder.settings_file_temp())
+        p = Process(PathBuilder.colorizer_cmd()).wait()
+        if p.returncode:
+            logging.error(f"error: <{p.stdout}>")
+            gui_utils.showErrorDialog(p.stdout)
+            return
+        lastMove = self.view.stlActor.lastMove
+        self.load_stl(PathBuilder.colorizer_stl(), colorize=True)
+        self.view.stlActor.lastMove = lastMove

--- a/src/controller/hardware.py
+++ b/src/controller/hardware.py
@@ -1,0 +1,54 @@
+"""Hardware helpers for controllers."""
+import logging
+
+from src.settings import PathBuilder
+
+logger = logging.getLogger(__name__)
+
+
+def create_printer():
+    """Load printer implementation lazily."""
+    try:
+        from src.hardware import printer
+
+        return printer.EpitPrinter()
+    except Exception as e:
+        logger.warning("printer is not initialized: %s", e)
+        return None
+
+
+def create_service(view, printer):
+    """Instantiate service tool for the given printer."""
+    if not printer:
+        return None, None
+
+    try:
+        from src.hardware import service
+
+        panel = service.ServicePanel(view)
+        panel.setModal(True)
+        controller = service.ServiceController(panel, service.ServiceModel(printer))
+        return panel, controller
+    except Exception as e:
+        logger.warning("service tool is unavailable: %s", e)
+        return None, None
+
+
+def create_calibration(view, printer):
+    """Instantiate calibration tool for the given printer."""
+    if not printer:
+        return None, None
+
+    try:
+        from src.hardware import calibration
+
+        panel = calibration.CalibrationPanel(view)
+        panel.setModal(True)
+        controller = calibration.CalibrationController(
+            panel,
+            calibration.CalibrationModel(printer, PathBuilder.calibration_file()),
+        )
+        return panel, controller
+    except Exception as e:
+        logger.warning("calibration tool is unavailable: %s", e)
+        return None, None

--- a/src/controller/hardware.py
+++ b/src/controller/hardware.py
@@ -1,4 +1,5 @@
 """Hardware helpers for controllers."""
+
 import logging
 
 from src.settings import PathBuilder

--- a/src/controller/main.py
+++ b/src/controller/main.py
@@ -43,6 +43,10 @@ from src.settings import (
 )
 import src.settings as settings
 
+from .hardware import create_printer, create_service, create_calibration
+from .ui_wiring import connect_signals
+from .file_management import FileManagementMixin
+
 logger = logging.getLogger(__name__)
 
 try:
@@ -51,55 +55,7 @@ except Exception:
     logger.warning("bug reporting is unavailable")
 
 
-def create_printer():
-    """Load printer implementation lazily."""
-    try:
-        from src.hardware import printer
-
-        return printer.EpitPrinter()
-    except Exception as e:
-        logger.warning("printer is not initialized: %s", e)
-        return None
-
-
-def create_service(view, printer):
-    """Instantiate service tool for the given printer."""
-    if not printer:
-        return None, None
-
-    try:
-        from src.hardware import service
-
-        panel = service.ServicePanel(view)
-        panel.setModal(True)
-        controller = service.ServiceController(panel, service.ServiceModel(printer))
-        return panel, controller
-    except Exception as e:
-        logger.warning("service tool is unavailable: %s", e)
-        return None, None
-
-
-def create_calibration(view, printer):
-    """Instantiate calibration tool for the given printer."""
-    if not printer:
-        return None, None
-
-    try:
-        from src.hardware import calibration
-
-        panel = calibration.CalibrationPanel(view)
-        panel.setModal(True)
-        controller = calibration.CalibrationController(
-            panel,
-            calibration.CalibrationModel(printer, PathBuilder.calibration_file()),
-        )
-        return panel, controller
-    except Exception as e:
-        logger.warning("calibration tool is unavailable: %s", e)
-        return None, None
-
-
-class MainController:
+class MainController(FileManagementMixin):
     def __init__(self, view, model, printer=None, service=None, calibration=None):
         self.view = view
         self.model = model
@@ -126,69 +82,7 @@ class MainController:
             self.bugReportDialog = bugReportDialog(self)
         except Exception:
             logger.warning("bug reporting is unavailable")
-        self._connect_signals()
-
-    def _connect_signals(self):
-        self.view.open_action.triggered.connect(self.open_file)
-        self.view.save_gcode_action.triggered.connect(partial(self.save_gcode_file))
-        self.view.save_sett_action.triggered.connect(self.save_settings_file)
-        self.view.save_project_action.triggered.connect(self.save_project)
-        self.view.save_project_as_action.triggered.connect(self.save_project_as)
-        self.view.load_sett_action.triggered.connect(self.load_settings_file)
-        self.view.slicing_info_action.triggered.connect(self.get_slicer_version)
-        self.view.documentation_action.triggered.connect(self.show_online_documentation)
-        self.view.check_updates_action.triggered.connect(self.open_updater)
-
-        if self.calibrationPanel is not None:
-            self.view.calibration_action.triggered.connect(self.calibration_action_show)
-        else:
-            self.view.calibration_action.triggered.connect(
-                lambda: showInfoDialog(locales.getLocale().ErrorHardwareModule)
-            )
-
-        try:
-            self.view.bug_report.triggered.connect(self.bugReportDialog.show)
-        except:
-            self.view.bug_report.triggered.connect(
-                lambda: showInfoDialog(locales.getLocale().ErrorBugModule)
-            )
-
-        # right panel
-        self.view.setts.get_element("printer_path", "add_btn").clicked.connect(
-            self.create_printer
-        )
-        self.view.setts.edit("printer_path").clicked.connect(self.choose_printer_path)
-
-        self.view.model_switch_box.stateChanged.connect(self.view.switch_stl_gcode)
-        self.view.model_centering_box.stateChanged.connect(self.view.model_centering)
-        self.view.picture_slider.valueChanged.connect(self.change_layer_view)
-        self.view.move_button.clicked.connect(self.move_model)
-        self.view.place_button.clicked.connect(self.place_model)
-        self.view.cancel_action.clicked.connect(partial(self.view.shift_state, True))
-        self.view.return_action.clicked.connect(partial(self.view.shift_state, False))
-        self.view.load_model_button.clicked.connect(self.open_file)
-        self.view.slice3a_button.clicked.connect(partial(self.slice_stl, "3axes"))
-        self.view.slice_vip_button.clicked.connect(partial(self.slice_stl, "vip"))
-        self.view.save_gcode_button.clicked.connect(self.save_gcode_file)
-        self.view.color_model_button.clicked.connect(self.colorize_model)
-
-        # bottom panel
-        self.view.add_plane_button.clicked.connect(self.add_splane)
-        self.view.add_cone_button.clicked.connect(self.add_cone)
-        self.view.edit_figure_button.clicked.connect(self.change_figure_parameters)
-        self.view.save_planes_button.clicked.connect(self.save_planes)
-        self.view.download_planes_button.clicked.connect(self.download_planes)
-        self.view.remove_plane_button.clicked.connect(self.remove_splane)
-        self.view.splanes_tree.itemClicked.connect(self.change_splanes_tree)
-        self.view.splanes_tree.itemChanged.connect(self.change_figure_check_state)
-        self.view.splanes_tree.currentItemChanged.connect(self.change_combo_select)
-        self.view.splanes_tree.model().rowsInserted.connect(self.moving_figure)
-
-        self.view.hide_checkbox.stateChanged.connect(self.view.hide_splanes)
-
-        # on close of window we save current planes to project file
-        self.view.before_closing_signal.connect(self.save_planes_on_close)
-        self.view.save_project_signal.connect(self.save_project)
+        connect_signals(self)
 
     def calibration_action_show(self):
         if not self.calibrationPanel:
@@ -565,43 +459,6 @@ class MainController:
     def place_model(self):
         self.view.stlActor.ResetColorize()
 
-    def open_file(self):
-        try:
-            filename = str(self.view.open_dialog(self.view.locale.OpenModel))
-            if filename != "":
-                file_ext = os.path.splitext(filename)[1].upper()
-                filename = str(Path(filename))
-                if file_ext == ".STL":
-                    self.reset_settings()
-                    s = sett()
-                    # copy stl file to project directory
-
-                    stl_full_path = PathBuilder.stl_model_temp()
-                    shutil.copyfile(filename, stl_full_path)
-                    # relative path inside project
-                    s.slicing.stl_filename = path.basename(filename)
-                    s.slicing.stl_file = path.basename(stl_full_path)
-
-                    self.save_settings("vip")
-                    self.update_interface(filename)
-
-                    self.view.model_centering_box.setChecked(False)
-
-                    if os.path.isfile(s.colorizer.copy_stl_file):
-                        os.remove(s.colorizer.copy_stl_file)
-
-                    self.load_stl(stl_full_path)
-                elif file_ext == ".GCODE":
-                    s = sett()
-                    # s.slicing.stl_file = filename # TODO optimize
-                    self.save_settings("vip")
-                    self.load_gcode(filename, False)
-                    self.update_interface(filename)
-                else:
-                    showErrorDialog("This file format isn't supported:" + file_ext)
-        except IOError as e:
-            showErrorDialog("Error during file opening:" + str(e))
-
     def reset_settings(self):
         s = sett()
         s.slicing.originx, s.slicing.originy, s.slicing.originz = 0, 0, 0
@@ -787,133 +644,6 @@ class MainController:
 
         if filename != "":
             save_settings(filename)
-
-    def save_gcode_file(self):
-        try:
-            name = str(self.view.save_gcode_dialog())
-            if name != "":
-                if not name.endswith(".gcode"):
-                    name += ".gcode"
-                copy2(PathBuilder.gcode_file(), name)
-        except IOError as e:
-            showErrorDialog("Error during file saving:" + str(e))
-
-    def save_settings_file(self):
-        try:
-            directory = (
-                "Settings_" + os.path.basename(sett().slicing.stl_file).split(".")[0]
-            )
-            filename = str(
-                self.view.save_dialog(
-                    self.view.locale.SaveSettings, "YAML (*.yaml *.YAML)", directory
-                )
-            )
-            if filename != "":
-                if not (filename.endswith(".yaml") or filename.endswith(".YAML")):
-                    filename += ".yaml"
-                self.save_settings("vip", filename)
-        except IOError as e:
-            showErrorDialog("Error during file saving:" + str(e))
-
-    def save_project_files(self, save_path=""):
-        if save_path == "":
-            self.save_settings("vip", PathBuilder.settings_file())
-            if os.path.isfile(PathBuilder.stl_model_temp()):
-                shutil.copy2(PathBuilder.stl_model_temp(), PathBuilder.stl_model())
-        else:
-            self.save_settings("vip", path.join(save_path, "settings.yaml"))
-            if os.path.isfile(PathBuilder.stl_model_temp()):
-                shutil.copy2(
-                    PathBuilder.stl_model_temp(), path.join(save_path, "model.stl")
-                )
-
-    def save_project(self):
-        try:
-            self.save_project_files()
-            create_temporary_project_files()
-            self.successful_saving_project()
-        except IOError as e:
-            showErrorDialog("Error during project saving: " + str(e))
-
-    def save_project_as(self):
-        project_path = PathBuilder.project_path()
-
-        try:
-            save_directory = str(
-                QFileDialog.getExistingDirectory(
-                    self.view, locales.getLocale().SavingProject
-                )
-            )
-
-            if not save_directory:
-                return
-
-            self.save_project_files(save_directory)
-            sett().project_path = save_directory
-            self.save_settings("vip", PathBuilder.settings_file())
-            create_temporary_project_files()
-            delete_temporary_project_files(project_path)
-
-            recent_projects = get_recent_projects()
-            update_last_open_project(recent_projects, save_directory)
-
-            self.successful_saving_project()
-
-        except IOError as e:
-            sett().project_path = project_path
-            self.save_settings("vip")
-            showErrorDialog("Error during project saving: " + str(e))
-
-    def successful_saving_project(self):
-        message_box = QMessageBox(parent=self.view)
-        message_box.setWindowTitle(locales.getLocale().SavingProject)
-        message_box.setText(locales.getLocale().ProjectSaved)
-        message_box.setIcon(QMessageBox.Information)
-        message_box.exec_()
-
-    def load_settings_file(self):
-        try:
-            filename = str(
-                self.view.open_dialog(
-                    self.view.locale.LoadSettings, "YAML (*.yaml *.YAML)"
-                )
-            )
-            if filename != "":
-                file_ext = os.path.splitext(filename)[1].upper()
-                filename = str(Path(filename))
-                if file_ext == ".YAML":
-                    try:
-                        # TODO: right now to maintain good transfer
-                        # we need to copy the project_path setting manually
-                        # everything else will work alright
-                        old_project_path = sett().project_path
-                        load_settings(filename)
-                        sett().project_path = old_project_path
-                        self.display_settings()
-                    except Exception as e:
-                        showErrorDialog("Error during reading settings file: " + str(e))
-                else:
-                    showErrorDialog("This file format isn't supported:" + file_ext)
-        except IOError as e:
-            showErrorDialog("Error during file opening:" + str(e))
-
-    def display_settings(self):
-        self.view.setts.reload()
-
-    def colorize_model(self):
-        shutil.copyfile(PathBuilder.stl_model_temp(), PathBuilder.colorizer_stl())
-        self.save_settings("vip", PathBuilder.settings_file_temp())
-
-        p = Process(PathBuilder.colorizer_cmd()).wait()
-        if p.returncode:
-            logging.error(f"error: <{p.stdout}>")
-            gui_utils.showErrorDialog(p.stdout)
-            return
-
-        lastMove = self.view.stlActor.lastMove
-        self.load_stl(PathBuilder.colorizer_stl(), colorize=True)
-        self.view.stlActor.lastMove = lastMove
-        # self.model.opened_stl = s.slicing.stl_file
 
     # ######################bottom panel
 

--- a/src/controller/main.py
+++ b/src/controller/main.py
@@ -4,17 +4,14 @@ import os
 from os import path
 import subprocess
 import time
-import sys
-from functools import partial
 from pathlib import Path
 import shutil
-from shutil import copy2
 from typing import Dict, List, Union
 from vtkmodules.vtkCommonMath import vtkMatrix4x4
 
 import vtk
 from PyQt5 import QtCore
-from PyQt5.QtCore import QSettings, QUrl
+from PyQt5.QtCore import QUrl
 from PyQt5.QtWidgets import QFileDialog, QInputDialog, QMessageBox
 from PyQt5.QtGui import QDesktopServices
 
@@ -33,13 +30,8 @@ from src.settings import (
     sett,
     save_settings,
     save_splanes_to_file,
-    load_settings,
     get_color,
     PathBuilder,
-    create_temporary_project_files,
-    update_last_open_project,
-    get_recent_projects,
-    delete_temporary_project_files,
 )
 import src.settings as settings
 

--- a/src/controller/ui_wiring.py
+++ b/src/controller/ui_wiring.py
@@ -1,0 +1,64 @@
+"""UI signal wiring for controllers."""
+from functools import partial
+
+from src import locales
+from src.gui_utils import showInfoDialog
+
+
+def connect_signals(controller):
+    view = controller.view
+    view.open_action.triggered.connect(controller.open_file)
+    view.save_gcode_action.triggered.connect(partial(controller.save_gcode_file))
+    view.save_sett_action.triggered.connect(controller.save_settings_file)
+    view.save_project_action.triggered.connect(controller.save_project)
+    view.save_project_as_action.triggered.connect(controller.save_project_as)
+    view.load_sett_action.triggered.connect(controller.load_settings_file)
+    view.slicing_info_action.triggered.connect(controller.get_slicer_version)
+    view.documentation_action.triggered.connect(controller.show_online_documentation)
+    view.check_updates_action.triggered.connect(controller.open_updater)
+
+    if controller.calibrationPanel is not None:
+        view.calibration_action.triggered.connect(controller.calibration_action_show)
+    else:
+        view.calibration_action.triggered.connect(
+            lambda: showInfoDialog(locales.getLocale().ErrorHardwareModule)
+        )
+
+    try:
+        view.bug_report.triggered.connect(controller.bugReportDialog.show)
+    except Exception:
+        view.bug_report.triggered.connect(
+            lambda: showInfoDialog(locales.getLocale().ErrorBugModule)
+        )
+
+    view.setts.get_element("printer_path", "add_btn").clicked.connect(
+        controller.create_printer
+    )
+    view.setts.edit("printer_path").clicked.connect(controller.choose_printer_path)
+    view.model_switch_box.stateChanged.connect(view.switch_stl_gcode)
+    view.model_centering_box.stateChanged.connect(view.model_centering)
+    view.picture_slider.valueChanged.connect(controller.change_layer_view)
+    view.move_button.clicked.connect(controller.move_model)
+    view.place_button.clicked.connect(controller.place_model)
+    view.cancel_action.clicked.connect(partial(view.shift_state, True))
+    view.return_action.clicked.connect(partial(view.shift_state, False))
+    view.load_model_button.clicked.connect(controller.open_file)
+    view.slice3a_button.clicked.connect(partial(controller.slice_stl, "3axes"))
+    view.slice_vip_button.clicked.connect(partial(controller.slice_stl, "vip"))
+    view.save_gcode_button.clicked.connect(controller.save_gcode_file)
+    view.color_model_button.clicked.connect(controller.colorize_model)
+
+    view.add_plane_button.clicked.connect(controller.add_splane)
+    view.add_cone_button.clicked.connect(controller.add_cone)
+    view.edit_figure_button.clicked.connect(controller.change_figure_parameters)
+    view.save_planes_button.clicked.connect(controller.save_planes)
+    view.download_planes_button.clicked.connect(controller.download_planes)
+    view.remove_plane_button.clicked.connect(controller.remove_splane)
+    view.splanes_tree.itemClicked.connect(controller.change_splanes_tree)
+    view.splanes_tree.itemChanged.connect(controller.change_figure_check_state)
+    view.splanes_tree.currentItemChanged.connect(controller.change_combo_select)
+    view.splanes_tree.model().rowsInserted.connect(controller.moving_figure)
+
+    view.hide_checkbox.stateChanged.connect(view.hide_splanes)
+    view.before_closing_signal.connect(controller.save_planes_on_close)
+    view.save_project_signal.connect(controller.save_project)

--- a/src/controller/ui_wiring.py
+++ b/src/controller/ui_wiring.py
@@ -1,4 +1,5 @@
 """UI signal wiring for controllers."""
+
 from functools import partial
 
 from src import locales

--- a/src/window/__init__.py
+++ b/src/window/__init__.py
@@ -1,0 +1,4 @@
+"""Window package providing the main application window."""
+from .main import MainWindow, TreeWidget
+
+__all__ = ["MainWindow", "TreeWidget"]

--- a/src/window/__init__.py
+++ b/src/window/__init__.py
@@ -1,4 +1,5 @@
 """Window package providing the main application window."""
+
 from .main import MainWindow, TreeWidget
 
 __all__ = ["MainWindow", "TreeWidget"]

--- a/src/window/dialogs.py
+++ b/src/window/dialogs.py
@@ -1,4 +1,5 @@
 """Dialog helpers for :mod:`src.window`."""
+
 import os
 import os.path as path
 from PyQt5.QtWidgets import QFileDialog
@@ -13,19 +14,27 @@ def _base_dir():
     return base_dir
 
 
-def save_dialog(parent, caption, format="STL (*.stl *.STL);;Gcode (*.gcode)", directory=""):
+def save_dialog(
+    parent, caption, format="STL (*.stl *.STL);;Gcode (*.gcode)", directory=""
+):
     base_dir = _base_dir()
     if directory:
-        directory = directory if path.isabs(directory) else path.join(base_dir, directory)
+        directory = (
+            directory if path.isabs(directory) else path.join(base_dir, directory)
+        )
     else:
         directory = base_dir
     return QFileDialog.getSaveFileName(parent, caption, directory, format)[0]
 
 
-def open_dialog(parent, caption, format="STL (*.stl *.STL);;Gcode (*.gcode)", directory=""):
+def open_dialog(
+    parent, caption, format="STL (*.stl *.STL);;Gcode (*.gcode)", directory=""
+):
     base_dir = _base_dir()
     if directory:
-        directory = directory if path.isabs(directory) else path.join(base_dir, directory)
+        directory = (
+            directory if path.isabs(directory) else path.join(base_dir, directory)
+        )
     else:
         directory = base_dir
     return QFileDialog.getOpenFileName(parent, caption, directory, format)[0]

--- a/src/window/dialogs.py
+++ b/src/window/dialogs.py
@@ -1,0 +1,31 @@
+"""Dialog helpers for :mod:`src.window`."""
+import os
+import os.path as path
+from PyQt5.QtWidgets import QFileDialog
+
+from src.settings import sett
+
+
+def _base_dir():
+    base_dir = getattr(sett(), "project_path", "") or os.getcwd()
+    if not base_dir or not path.isdir(base_dir):
+        base_dir = path.expanduser("~")
+    return base_dir
+
+
+def save_dialog(parent, caption, format="STL (*.stl *.STL);;Gcode (*.gcode)", directory=""):
+    base_dir = _base_dir()
+    if directory:
+        directory = directory if path.isabs(directory) else path.join(base_dir, directory)
+    else:
+        directory = base_dir
+    return QFileDialog.getSaveFileName(parent, caption, directory, format)[0]
+
+
+def open_dialog(parent, caption, format="STL (*.stl *.STL);;Gcode (*.gcode)", directory=""):
+    base_dir = _base_dir()
+    if directory:
+        directory = directory if path.isabs(directory) else path.join(base_dir, directory)
+    else:
+        directory = base_dir
+    return QFileDialog.getOpenFileName(parent, caption, directory, format)[0]

--- a/src/window/main.py
+++ b/src/window/main.py
@@ -7,7 +7,6 @@ from PyQt5.QtWidgets import (
     QMainWindow,
     QWidget,
     QLabel,
-    QComboBox,
     QGridLayout,
     QSlider,
     QCheckBox,
@@ -16,6 +15,7 @@ from PyQt5.QtWidgets import (
     QScrollArea,
     QGroupBox,
     QDialog,
+    QFileDialog,
     QTreeWidget,
     QTreeWidgetItem,
     QAbstractItemView,
@@ -35,8 +35,6 @@ from src.settings import (
 from src.figure_editor import StlMovePanel
 from src.settings_widget import SettingsWidget
 from . import menu, rendering, dialogs
-import os
-import os.path as path
 import logging
 
 NothingState = "nothing"
@@ -247,17 +245,6 @@ class MainWindow(QMainWindow):
         right_panel.setColumnStretch(1, 1)
         right_panel.setColumnStretch(3, 1)
         right_panel.setColumnStretch(4, 1)
-
-        сolumn2_number_of_cells = 4
-
-        validatorLocale = QtCore.QLocale("Englishs")
-        intValidator = QtGui.QIntValidator(0, 9000)
-
-        doubleValidator = QtGui.QDoubleValidator(0.00, 9000.00, 2)
-        doubleValidator.setLocale(validatorLocale)
-
-        doublePercentValidator = QtGui.QDoubleValidator(0.00, 9000.00, 2)
-        doublePercentValidator.setLocale(validatorLocale)
 
         # Front-end development at its best
         self.cur_row = 1
@@ -521,7 +508,7 @@ class MainWindow(QMainWindow):
 
         self.stlActor.SetUserTransform(transform)
 
-        if not self.boxWidget is None:
+        if self.boxWidget is not None:
             self.boxWidget.SetTransform(transform)
 
         self.updateTransform()
@@ -712,7 +699,7 @@ class MainWindow(QMainWindow):
         transform = movements[current_index][1]
 
         self.stlActor.SetUserTransform(transform)
-        if not self.boxWidget is None:
+        if self.boxWidget is not None:
             self.boxWidget.SetTransform(transform)
 
         self.updateTransform()
@@ -737,10 +724,14 @@ class MainWindow(QMainWindow):
         i, j, k = tf.GetOrientation()
         self.xyz_orient_value.setText(f"Orientation: {i:.2f} {j:.2f} {k:.2f}")
 
-    def save_dialog(self, caption, format="STL (*.stl *.STL);;Gcode (*.gcode)", directory=""):
+    def save_dialog(
+        self, caption, format="STL (*.stl *.STL);;Gcode (*.gcode)", directory=""
+    ):
         return dialogs.save_dialog(self, caption, format, directory)
 
-    def open_dialog(self, caption, format="STL (*.stl *.STL);;Gcode (*.gcode)", directory=""):
+    def open_dialog(
+        self, caption, format="STL (*.stl *.STL);;Gcode (*.gcode)", directory=""
+    ):
         return dialogs.open_dialog(self, caption, format, directory)
 
     def load_stl(self, stl_actor):
@@ -809,7 +800,7 @@ class MainWindow(QMainWindow):
                 )
 
             row = self.splanes_tree.topLevelItem(i)
-            if row != None:
+            if row is not None:
                 if (
                     row.checkState(0) == QtCore.Qt.CheckState.Checked
                 ) or self.hide_checkbox.isChecked():

--- a/src/window/menu.py
+++ b/src/window/menu.py
@@ -1,0 +1,49 @@
+"""Menu helpers for :mod:`src.window`."""
+from PyQt5.QtWidgets import QAction
+from src import locales
+
+
+def setup_menus(window):
+    """Populate application menus and actions for ``window``.
+
+    Parameters
+    ----------
+    window:
+        Instance of :class:`~PyQt5.QtWidgets.QMainWindow` to populate.
+    """
+    locale = window.locale
+    bar = window.menuBar()
+
+    file_menu = bar.addMenu(locale.File)
+    window.open_action = QAction(locale.Open, window)
+    file_menu.addAction(window.open_action)
+
+    window.save_gcode_action = QAction(locale.SaveGCode, window)
+    window.save_project_action = QAction(locale.SaveProject, window)
+    file_menu.addAction(window.save_project_action)
+    window.save_project_as_action = QAction(locale.SaveProjectAs, window)
+    file_menu.addAction(window.save_project_as_action)
+    file_menu.addAction(window.save_gcode_action)
+    window.save_sett_action = QAction(locale.SaveSettings, window)
+    file_menu.addAction(window.save_sett_action)
+    window.load_sett_action = QAction(locale.LoadSettings, window)
+    file_menu.addAction(window.load_sett_action)
+
+    window.slicing_info_action = QAction(locale.SlicerInfo, window)
+    file_menu.addAction(window.slicing_info_action)
+
+    tools_menu = bar.addMenu(locale.Tools)
+    window.calibration_action = QAction(locale.Calibration, window)
+    tools_menu.addAction(window.calibration_action)
+    window.bug_report = QAction(locale.SubmitBugReport, window)
+    tools_menu.addAction(window.bug_report)
+
+    window.check_updates_action = QAction(locale.CheckUpdates, window)
+    tools_menu.addAction(window.check_updates_action)
+
+    help_menu = bar.addMenu(locale.Help)
+    window.slicing_info_action = QAction(locale.SlicerInfo, window)
+    help_menu.addAction(window.slicing_info_action)
+
+    window.documentation_action = QAction(locale.Documentation, window)
+    help_menu.addAction(window.documentation_action)

--- a/src/window/menu.py
+++ b/src/window/menu.py
@@ -1,6 +1,6 @@
 """Menu helpers for :mod:`src.window`."""
+
 from PyQt5.QtWidgets import QAction
-from src import locales
 
 
 def setup_menus(window):

--- a/src/window/rendering.py
+++ b/src/window/rendering.py
@@ -1,4 +1,5 @@
 """3D rendering utilities for :mod:`src.window`."""
+
 import vtk
 from vtk.qt.QVTKRenderWindowInteractor import QVTKRenderWindowInteractor
 

--- a/src/window/rendering.py
+++ b/src/window/rendering.py
@@ -1,0 +1,70 @@
+"""3D rendering utilities for :mod:`src.window`."""
+import vtk
+from vtk.qt.QVTKRenderWindowInteractor import QVTKRenderWindowInteractor
+
+from src.InteractorAroundActivePlane import InteractionAroundActivePlane
+from src import gui_utils
+from src.settings import get_color
+
+
+def init_3d_widget(window):
+    """Create and initialize the VTK rendering widget for ``window``."""
+    widget3d = QVTKRenderWindowInteractor(window)
+    widget3d.installEventFilter(window)
+
+    window.render = vtk.vtkRenderer()
+    window.render.SetBackground(get_color("white"))
+
+    widget3d.GetRenderWindow().AddRenderer(window.render)
+    window.interactor = widget3d.GetRenderWindow().GetInteractor()
+    window.interactor.SetInteractorStyle(None)
+
+    window.interactor.Initialize()
+    window.interactor.Start()
+
+    # set position of camera to (5, 5, 5) and look at (0, 0, 0)
+    window.render.GetActiveCamera().SetPosition(5, 5, 5)
+    window.render.GetActiveCamera().SetFocalPoint(0, 0, 0)
+    window.render.GetActiveCamera().SetViewUp(0, 0, 1)
+
+    window.customInteractor = InteractionAroundActivePlane(
+        window.interactor, window.render
+    )
+    window.interactor.AddObserver(
+        "MouseWheelBackwardEvent", window.customInteractor.middleBtnPress
+    )
+    window.interactor.AddObserver(
+        "MouseWheelForwardEvent", window.customInteractor.middleBtnPress
+    )
+    window.interactor.AddObserver(
+        "RightButtonPressEvent", window.customInteractor.rightBtnPress
+    )
+    window.interactor.AddObserver(
+        "RightButtonReleaseEvent", window.customInteractor.rightBtnPress
+    )
+    window.interactor.AddObserver(
+        "LeftButtonPressEvent",
+        lambda obj, event: window.customInteractor.leftBtnPress(obj, event, window),
+    )
+    window.interactor.AddObserver(
+        "LeftButtonReleaseEvent", window.customInteractor.leftBtnPress
+    )
+    window.interactor.AddObserver(
+        "MouseMoveEvent",
+        lambda obj, event: window.customInteractor.mouseMove(obj, event, window),
+    )
+
+    window.axesWidget = gui_utils.createAxes(window.interactor)
+
+    window.planeActor = gui_utils.createPlaneActorCircle()
+    window.planeTransform = vtk.vtkTransform()
+    window.render.AddActor(window.planeActor)
+
+    window.add_legend()
+
+    window.splanes_actors = []
+
+    widget3d.Initialize()
+    widget3d.Start()
+
+    return widget3d


### PR DESCRIPTION
## Summary
- Split the monolithic window implementation into menu, rendering and dialog helpers
- Break up controller responsibilities into dedicated file management mixin, hardware helpers and UI wiring
- Expose `MainWindow` and `MainController` through package-level `__init__` with optional Qt imports

## Testing
- `./run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_b_68c82974f3948331a0ac0de12cd6f2e7