### PR TITLE
Adjust pressure advance defaults and precision

### DIFF
--- a/settings.yaml
+++ b/settings.yaml
@@ -101,7 +101,7 @@ slicing:
   material_shrinkage: 0.0
   flow_rate: 100
   pressure_advance_on: true
-  pressure_advance: 0.45
+  pressure_advance: 0.045
   mesh_file: lib/goosli_middle.msh
   minimum_path_area: 0.001
   model_centering: false


### PR DESCRIPTION
## Summary
- set the default pressure advance setting to 0.045
- add reusable spinbox overrides and apply three-decimal precision to the pressure advance control

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68db97ec4bb8833397bce5d8be92ed18